### PR TITLE
Reorder sections

### DIFF
--- a/api/routes/clubsRoute.js
+++ b/api/routes/clubsRoute.js
@@ -268,6 +268,7 @@ router.get(
           'sections.order',
           'sections.club_id'
         )
+        .orderBy('order')
       res.status(200).json(sections)
     } catch (err) {
       res.status(500).json(err)

--- a/client/src/auth/Auth.js
+++ b/client/src/auth/Auth.js
@@ -8,8 +8,8 @@ class Auth {
   auth0 = new auth0.WebAuth({
     domain: 'club-handbook.auth0.com',
     clientID: 'LL5WL3YD7vxOZ5tw5yMDmtQb2QxRpTkU',
-    redirectUri: 'https://clubhandbook.netlify.com/callback',
-    // redirectUri: 'http://localhost:3000/callback',
+    // redirectUri: 'https://clubhandbook.netlify.com/callback',
+    redirectUri: 'http://localhost:3000/callback',
     audience: 'https://club-handbook.herokuapp.com/',
     responseType: 'token id_token',
     scope: 'openid profile email',

--- a/client/src/components/handbook/HandbookPage.js
+++ b/client/src/components/handbook/HandbookPage.js
@@ -133,6 +133,8 @@ class HandbookPage extends React.Component {
           <HandbookRender
             displayHandbook={this.state.displayHandbook}
             cancel={this.cancel}
+            sections={this.props.sections}
+            loading={this.props.loading}
           />
 
           {this.state.editView ? (
@@ -164,6 +166,7 @@ const mapStateToProps = state => {
     currentUser: state.auth.currentUser,
     club: state.clubs.clubById,
     sections: state.clubs.sections,
+    loading: state.clubs.loading,
   }
 }
 

--- a/client/src/components/handbook/HandbookRender.js
+++ b/client/src/components/handbook/HandbookRender.js
@@ -1,13 +1,14 @@
 import React from 'react'
-import { connect } from 'react-redux'
 import renderHTML from 'react-render-html'
 import { HandbookContainer, HandbookPreview } from '../../style/handbook'
 import { Close } from '@material-ui/icons'
 
 const SectionRender = props => {
-  if (props.sections.length === 0) {
-    return <h1>No sections loaded on this component...</h1>
-  } else if (props.displayHandbook) {
+  if (props.loading) {
+    return <h1>Loading...</h1>
+  } else if (props.sections.length === 0) {
+    return <h1>Please create a handbook and add some sections.</h1>
+  } else if (props.displayHandbook && props.sections) {
     return (
       <HandbookPreview displayOn>
         <Close onClick={props.cancel} />
@@ -24,8 +25,7 @@ const SectionRender = props => {
         })}
       </HandbookPreview>
     )
-  }
-  {
+  } else {
     return (
       <HandbookPreview>
         {props.sections.map(section => {
@@ -44,13 +44,4 @@ const SectionRender = props => {
   }
 }
 
-const mapStateToProps = state => {
-  return {
-    sections: state.clubs.sections,
-  }
-}
-
-export default connect(
-  mapStateToProps,
-  {}
-)(SectionRender)
+export default SectionRender

--- a/client/src/components/handbook/views/SectionsView.js
+++ b/client/src/components/handbook/views/SectionsView.js
@@ -3,14 +3,13 @@ import SectionItem from './SectionItem'
 import { Typography } from '@material-ui/core'
 import { AddCircle, FormatLineSpacing } from '@material-ui/icons'
 import { Row, Column, iconSize } from '../../../style/layout'
+import { connect } from 'react-redux'
+import { updateSection } from '../../../store/actions/clubActions'
 const update = require('immutability-helper')
 
 class SectionsView extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      sections: this.props.sections,
-    }
+  state = {
+    sections: this.props.sections,
   }
 
   moveSection = (dragIndex, hoverIndex) => {
@@ -24,6 +23,19 @@ class SectionsView extends Component {
         },
       })
     )
+
+    this.updateSectionOrder(this.state.sections)
+  }
+
+  updateSectionOrder = sections => {
+    console.log('updating section after dnd')
+    sections.map((section, idx) => {
+      // console.log('section order', section.title, section.order)
+      const orderUpdate = { order: idx + 1 }
+      // console.log('section order', section.title, section.order)
+      console.log(section.club_id, section.id, orderUpdate)
+      this.props.updateSection(section.club_id, section.id, orderUpdate)
+    })
   }
 
   render() {
@@ -58,4 +70,7 @@ class SectionsView extends Component {
   }
 }
 
-export default SectionsView
+export default connect(
+  null,
+  { updateSection }
+)(SectionsView)


### PR DESCRIPTION
- the order position is now updated in the backend during reordering of the sections

- get sections will now order the array by 'order' position

- handbook render also displays the sections in the correct order

- but there is a bug where reordering and updating the section will crash the app and is part of the bug already listed
